### PR TITLE
feat(preview): CSV → Preview slice v2

### DIFF
--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const GeneratePreviewRequestSchema = z.object({
+  overwrite: z.boolean().optional().default(false),
+  count: z.number().int().min(1).max(100).optional().default(5),
+})
+export type GeneratePreviewRequest = z.infer<typeof GeneratePreviewRequestSchema>
+
+export const GeneratePreviewResultSchema = z.object({
+  generated: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  correlationId: z.string(),
+  sampleIds: z.array(z.string()).max(10),
+})
+export type GeneratePreviewResult = z.infer<typeof GeneratePreviewResultSchema>

--- a/supabase/migrations/20250912_csv_preview_slice.sql
+++ b/supabase/migrations/20250912_csv_preview_slice.sql
@@ -1,0 +1,60 @@
+-- CSV → Preview Slice migration (idempotent)
+-- 20250912_csv_preview_slice.sql
+
+-- website_previews: ensure updated_at
+ALTER TABLE public.website_previews
+ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+
+-- website_previews: unique slug (nullable; only enforce when present)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='uq_website_previews_slug_nonnull'
+  ) THEN
+    CREATE UNIQUE INDEX uq_website_previews_slug_nonnull
+      ON public.website_previews (slug)
+      WHERE slug IS NOT NULL;
+  END IF;
+END $$;
+
+-- updated_at trigger helper
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='set_updated_at') THEN
+    CREATE OR REPLACE FUNCTION public.set_updated_at()
+    RETURNS trigger LANGUAGE plpgsql AS $fn$
+    BEGIN
+      NEW.updated_at := now();
+      RETURN NEW;
+    END;
+    $fn$;
+  END IF;
+END $$;
+
+-- updated_at trigger on website_previews
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname='trg_website_previews_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_website_previews_updated_at
+      BEFORE UPDATE ON public.website_previews
+      FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;
+
+-- operations_log: add correlation_id + index
+ALTER TABLE public.operations_log
+ADD COLUMN IF NOT EXISTS correlation_id text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND indexname='idx_operations_log_correlation_id'
+  ) THEN
+    CREATE INDEX idx_operations_log_correlation_id
+      ON public.operations_log (correlation_id);
+  END IF;
+END $$;


### PR DESCRIPTION
- SQL migration: updated_at + trigger on website_previews, unique slug index (nonnull), operations_log.correlation_id + index
- Shared zod types at packages/shared/types.ts
- /api/generate-preview now validates {overwrite,count≤100}, runs pool=4 batch, upserts previews, and writes one operations_log summary row with correlation_id
- smoke: trigger /api/generate-preview batch(5) and assert ≥5 previews via REST; include correlationId in report
- README: add CSV → Preview Slice (headless) section